### PR TITLE
Find and complete small todo item

### DIFF
--- a/src/util/value_string.rs
+++ b/src/util/value_string.rs
@@ -26,8 +26,10 @@ impl HeaderValueString {
     }
 
     pub(crate) fn as_str(&self) -> &str {
-        // HeaderValueString is only created from HeaderValues
-        // that have validated they are also UTF-8 strings.
+        // SAFETY: HeaderValueString is only created from HeaderValues that have been
+        // validated to be valid UTF-8 strings. All constructors (`try_from_header_value`,
+        // `from_string`, and `from_static`) ensure the HeaderValue can be represented as
+        // a valid UTF-8 string before wrapping it in HeaderValueString.
         unsafe { std::str::from_utf8_unchecked(self.0.as_bytes()) }
     }
 


### PR DESCRIPTION
Added a SAFETY comment following Rust conventions to document why the unsafe `from_utf8_unchecked` call is safe. The comment clarifies that all constructors validate UTF-8 before creating a HeaderValueString.